### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,9 @@
 name: Security Scanning
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/Fayeblade1488/FayeBlade-Qwen-CLI-Patch/security/code-scanning/6](https://github.com/Fayeblade1488/FayeBlade-Qwen-CLI-Patch/security/code-scanning/6)

To fix this issue, you should add a `permissions` block to the workflow (either at the root level or under the relevant job(s)). Since the only step that interacts with GitHub beyond reading code is uploading an artifact (which does not require write access to repository contents, issues, or pull requests), the minimal permissions should be:

- `contents: read` (to access repository code)
- `actions: write` (required for `actions/upload-artifact`)

If you wish to be especially strict, you can set these permissions at the job level (`security` job) but it's common to do it at the root so future jobs without explicit permissions inherit a safe default.  

**Change required:**  
In `.github/workflows/security.yml`, insert the following block after the workflow `name` and before the `on:` block:

```yaml
permissions:
  contents: read
  actions: write
```

No external libraries, imports, or variable definitions are needed. Only a YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Insert a permissions block in security.yml specifying contents: read and actions: write